### PR TITLE
label tomcat:8.0 no longer exists on dockerhub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 tomcat:
   container_name: ${SERVICE_NAME}
   restart: always
-  image: tomcat:8.0
+  image: tomcat:8
   net: ${DOCKER_NETWORK_NAME}
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Fix to issue: https://github.com/Accenture/adop-cartridge-java-environment-template/issues/6

Changed docker-compose to use tomcat:8

Tested:
1. Create_Environment job now works
1. Reference_Application_Deploy job deploys
1. PetClinic environment still works.