### PR TITLE
Locking minor version of Tomcat to 8.0.50

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 tomcat:
   container_name: ${SERVICE_NAME}
   restart: always
-  image: tomcat:8.0
+  image: tomcat:8.0.50
   net: ${DOCKER_NETWORK_NAME}
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Due to recent changes in main Tomcat 8.0 image we have broken DOA because they are now have requirements for more explicit configuration in Tomcat to response when we request websites via domain names.

In this PR, I'm just rolling back changes in Tomcat by falling back to previous minor version of Tomcat docker image.

By container name - doesn't work:
```
root@0beb9d5af38b:/etc/nginx/sites-enabled# curl -I http://DOA_Labs_Module3_FOSS_Java_Manual_CI:8080/petclinic
HTTP/1.1 400 Bad Request
Server: Apache-Coyote/1.1
Transfer-Encoding: chunked
Date: Tue, 15 May 2018 08:30:06 GMT
Connection: close
```

By IP address - it works:
```
root@0beb9d5af38b:/# curl -I http://172.18.0.28:8080/petclinic/
HTTP/1.1 200 OK
Server: Apache-Coyote/1.1
Set-Cookie: JSESSIONID=5E6A4D4F7060D04A603D7224DDC25A03; Path=/petclinic; HttpOnly
Content-Type: text/html;charset=UTF-8
Content-Language: en
Content-Length: 0
Date: Tue, 15 May 2018 09:03:42 GMT
```